### PR TITLE
Motor voltages on X/Y are too high. reduce them to prevent overheat failures

### DIFF
--- a/printer.cfg
+++ b/printer.cfg
@@ -142,7 +142,7 @@ pin: FAN0
 [tmc2209 stepper_x]
 uart_pin: X_CS
 interpolate: False
-run_current: 1.1
+run_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 200                          # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 diag_pin: PA4  										# YOU NEED TO JUMP THIS DIAG PIN ON YOUR BOARD FOR SENSORLESS HOMING TO WORK 
@@ -152,7 +152,7 @@ driver_SGTHRS: 70									# 255 is most sensitive value, 0 is least sensitive
 [tmc2209 stepper_y]
 uart_pin: Y_CS
 interpolate: False
-run_current: 1.1
+run_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 200                          # Set to 999999 to turn stealthchop on, and 0 to use spreadcycle
 diag_pin: PA5 										# YOU NEED TO JUMP THIS DIAG PIN ON YOUR BOARD FOR SENSORLESS HOMING TO WORK 


### PR DESCRIPTION
X/Y should not be at 1.1

This will cause the motors to heat unnecessarily, and risk failures on long prints.  Setting them to 0.8 still provides enough torque to print without issues, while removing one likely failure point.